### PR TITLE
Update README.md test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ you should run the tests:
 pip install -e .
 
 # Run the python tests. This should not give you a few sucessful example tests
+# You may need to install nbval first: pip install nbval
 py.test
 
 # Run the JS tests. This should again, only give TODO errors (Expected 'Value' to equal 'Expected value'):
-cd ts
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ you should run the tests:
 
 ```bash
 # First install the python package. This will also build the JS packages.
-pip install -e .
+pip install -e ".[test, examples]".
 
 # Run the python tests. This should not give you a few sucessful example tests
-# You may need to install nbval first: pip install nbval
 py.test
 
 # Run the JS tests. This should again, only give TODO errors (Expected 'Value' to equal 'Expected value'):


### PR DESCRIPTION
The instructions seem to be outdated.

This PR indicates that it is necessary to install nbval and it removes the `cd ts` command, since the `package.json` is in the root