### PR TITLE
Implements what jupyter/notebook#3116 makes possible

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -46,7 +46,8 @@ package_data_spec = {
 data_files_spec = [
     ('share/jupyter/nbextensions/{{ cookiecutter.npm_package_name }}',
         pjoin(nb_path, '*.js*')),
-    ('share/jupyter/lab/extensions', lab_path)
+    ('share/jupyter/lab/extensions', lab_path),
+    ('etc/jupyter/nbconfig/notebook.d/' , '{{ cookiecutter.npm_package_name }}.json')
 ]
 
 

--- a/{{cookiecutter.github_project_name}}/{{cookiecutter.npm_package_name}}.json
+++ b/{{cookiecutter.github_project_name}}/{{cookiecutter.npm_package_name}}.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "{{ cookiecutter.npm_package_name }}/extension": true
+  }
+}


### PR DESCRIPTION
Enable nbextension at installation, only makes sense to merge when https://github.com/jupyter/notebook/pull/3116 is merged.