### PR TITLE
Update packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ of those flags here.
 - Relase the npm packages:
   ```bash
   npm login
-  cd ts
   npm publish
   # Now, you need to update the entry in /<your python package>/jlextension/package.json
   # from "file:../../ts" to "^<the version of the NPM packge you just released>

--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ of those flags here.
   ```bash
   npm login
   npm publish
-  # Now, you need to update the entry in /<your python package>/jlextension/package.json
-  # from "file:../../ts" to "^<the version of the NPM packge you just released>
-  # After this, run:
-  cd ../<your python package>/jlextension
-  npm publish
   ```
 - Bundle the python package: `python setup.py sdist bdist_wheel`
 - Publish the package to PyPI:


### PR DESCRIPTION
There doesn't seem to be a `ts` folder in this cookiecutter (but the javascript one does have a `js` folder).
So we should be good to remove the `cd ts` step from the packaging instructions!