### PR TITLE
add embeddable bundle

### DIFF
--- a/{{cookiecutter.github_project_name}}/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/webpack.config.js
@@ -6,6 +6,8 @@ const rules = [
 
 // Packages that shouldn't be bundled but loaded at runtime
 const externals = ['@jupyter-widgets/base', 'three', 'jupyter-threejs'];
+var version = require('./package.json').version;
+var path = require('path');
 
 module.exports = [
   {
@@ -46,4 +48,35 @@ module.exports = [
       extensions: [".webpack.js", ".web.js", ".ts", ".js"]
     },
   },
+  {// Embeddable {{ cookiecutter.npm_package_name }} bundle
+    //
+    // This bundle is generally almost identical to the notebook bundle
+    // containing the custom widget views and models.
+    //
+    // The only difference is in the configuration of the webpack public path
+    // for the static assets.
+    //
+    // It will be automatically distributed by unpkg to work with the static
+    // widget embedder.
+    //
+    // The target bundle is always `dist/index.js`, which is the path required
+    // by the custom widget embedder.
+    //
+    entry: './src/index.ts',
+    output: {
+        filename: 'index.js',
+        path: path.resolve(__dirname, 'dist'),
+        libraryTarget: 'amd',
+        publicPath: 'https://unpkg.com/{{ cookiecutter.npm_package_name }}@' + version + '/dist/'
+    },
+    devtool: 'source-map',
+    module: {
+        rules: rules
+    },
+    externals: ['@jupyter-widgets/base'],
+    resolve: {
+      // Add '.ts' and '.tsx' as resolvable extensions.
+      extensions: [".webpack.js", ".web.js", ".ts", ".js"]
+    },
+  }
 ];

--- a/{{cookiecutter.github_project_name}}/webpack.config.js
+++ b/{{cookiecutter.github_project_name}}/webpack.config.js
@@ -67,6 +67,7 @@ module.exports = [
         filename: 'index.js',
         path: path.resolve(__dirname, 'dist'),
         libraryTarget: 'amd',
+        library: "{{ cookiecutter.npm_package_name }}", 
         publicPath: 'https://unpkg.com/{{ cookiecutter.npm_package_name }}@' + version + '/dist/'
     },
     devtool: 'source-map',


### PR DESCRIPTION
I was able to get my custom widget (built using this cookie-ts-cutter) to be embeddable in an exported HTML file and render on NBviewer after making this change. This was referenced in issue #29 and proposed by @jasongrout (there was also an additional change proposed to the package.json, which I'll include an another commit).