### PR TITLE
Add missing tsconfig.json file in MANIFEST

### DIFF
--- a/{{cookiecutter.github_project_name}}/MANIFEST.in
+++ b/{{cookiecutter.github_project_name}}/MANIFEST.in
@@ -5,6 +5,7 @@ include setupbase.py
 include pytest.ini
 include .coverage.rc
 
+include tsconfig.json
 include package.json
 include webpack.config.js
 include {{ cookiecutter.python_package_name }}/labextension/*.tgz


### PR DESCRIPTION
This file must be added, it is needed when building the conda package