### PR TITLE
convert hyphens to underscore for python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ script:
   - make linkcheck
   - popd
   # Make a non-local install so the data_files get populated
-  - pip uninstall -y ipywidgettestwidgets
+  - pip uninstall -y jupyter_widget_testwidgets
   - pip install .
-  - jupyter nbextension enable --py --sys-prefix ipywidgettestwidgets
+  - jupyter nbextension enable --py --sys-prefix jupyter_widget_testwidgets
   # Validate nbextension (enable does not use exit code):
-  - python -c "from notebook.nbextensions import validate_nbextension; import sys; sys.exit(validate_nbextension('ipywidgettestwidgets/extension') or 0)"
+  - python -c "from notebook.nbextensions import validate_nbextension; import sys; sys.exit(validate_nbextension('jupyter_widget_testwidgets/extension') or 0)"
   - pip install jupyterlab
   # Make sure our lab extension was installed.
   - jupyter labextension list

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
 	"author_email": "",
 	"github_project_name": "",
 	"github_organization_name": "",
-	"python_package_name": "{{ cookiecutter.github_project_name }}",
+	"python_package_name": "{{ cookiecutter.github_project_name | replace('-', '_') }}",
 	"npm_package_name": "{{ cookiecutter.github_project_name }}",
     "npm_package_version": "0.1.0",
 	"project_short_description": "A Custom Jupyter Widget Library"

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -29,7 +29,7 @@ def example_instance(tmpdir_factory):
                 yield instance_path
             finally:
                 try:
-                    pip.main(['uninstall', 'ipywidgettestwidgets', '-y'])
+                    pip.main(['uninstall', 'jupyter_widget_testwidgets', '-y'])
                 except Exception:
                     pass
 

--- a/tests/testconfig.yaml
+++ b/tests/testconfig.yaml
@@ -3,7 +3,7 @@ default_context:
     author_email: "testwidget@example.com"
     github_project_name: "jupyter-widget-testwidgets"
     github_organization_name: "jupyter"
-    python_package_name: "ipywidgettestwidgets"
+    python_package_name: "jupyter-widget-testwidgets"
     npm_package_name: "@jupyter-widgets/jupyter-widget-testwidgets"
     npm_package_version: "1.1.0"
     project_short_description: "A Test Jupyter Widget Library"

--- a/tests/testconfig.yaml
+++ b/tests/testconfig.yaml
@@ -3,7 +3,6 @@ default_context:
     author_email: "testwidget@example.com"
     github_project_name: "jupyter-widget-testwidgets"
     github_organization_name: "jupyter"
-    python_package_name: "jupyter-widget-testwidgets"
     npm_package_name: "@jupyter-widgets/jupyter-widget-testwidgets"
     npm_package_version: "1.1.0"
     project_short_description: "A Test Jupyter Widget Library"


### PR DESCRIPTION
Should close #54 

Simpler version of: https://github.com/jupyter-widgets/widget-ts-cookiecutter/pull/70

This allows the typescript package to have hyphens, but converts them to dashes for the python package.