### PR TITLE
don't use strictPropertyInitialization

### DIFF
--- a/{{cookiecutter.github_project_name}}/tsconfig.json
+++ b/{{cookiecutter.github_project_name}}/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
+    "strictPropertyInitialization": false,
     "target": "es2015"
   },
   "include": [


### PR DESCRIPTION
allows initializing attributes in the `initialize` function run by backbonejs see: https://backbonejs.org/#Model-constructor

@martinRenou 