### PR TITLE
remove jupyter_sphinx warning

### DIFF
--- a/{{cookiecutter.github_project_name}}/docs/environment.yml
+++ b/{{cookiecutter.github_project_name}}/docs/environment.yml
@@ -8,4 +8,4 @@ dependencies:
 - numpy
 - sphinx
 - nbsphinx
-- jupyter_sphinx
+- jupyter_sphinx>=0.2.4

--- a/{{cookiecutter.github_project_name}}/docs/source/conf.py
+++ b/{{cookiecutter.github_project_name}}/docs/source/conf.py
@@ -29,7 +29,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'nbsphinx',
-    'jupyter_sphinx.execute',
+    'jupyter_sphinx',
     'nbsphinx_link',
 ]
 

--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -102,7 +102,7 @@ setup_args = dict(
             'recommonmark',
             'sphinx_rtd_theme',
             'nbsphinx>=0.2.13,<0.4.0',
-            'jupyter_sphinx',
+            'jupyter_sphinx>=0.2.4',
             'nbsphinx-link',
             'pytest_check_links',
             'pypandoc',


### PR DESCRIPTION
Using jupyter_sphinx.execute is a warning in version 0.2.4 and will be an error in version 0.3.0