### PR TITLE
Update for JupyterLab 3

### DIFF
--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -29,15 +29,14 @@
     "url": "https://github.com/{{ cookiecutter.github_organization_name }}/{{ cookiecutter.github_project_name }}"
   },
   "scripts": {
-    "build": "npm run build:lib && npm run build:nbextension",
+    "build": "npm run build:lib && npm run build:nbextension && npm run build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
     "build:nbextension": "webpack -p",
-    "build:all": "npm run build:labextension && npm run build:nbextension",
-    "clean": "npm run clean:lib && npm run clean:nbextension",
+    "clean": "npm run clean:lib && npm run clean:nbextension && npm run clean:labextension",
     "clean:lib": "rimraf lib",
-    "clean:labextension": "rimraf {{ cookiecutter.python_package_name }}/jupyterlab_widgets/lab3extension",
+    "clean:labextension": "rimraf {{ cookiecutter.python_package_name }}/labextension",
     "clean:nbextension": "rimraf {{ cookiecutter.python_package_name }}/nbextension/static/index.js",
     "lint": "eslint . --ext .ts,.tsx --fix",
     "lint:check": "eslint . --ext .ts,.tsx",
@@ -93,7 +92,7 @@
   },
   "jupyterlab": {
     "extension": "lib/plugin",
-    "outputDir": "jupyterlab_widgets/static",
+    "outputDir": "{{ cookiecutter.python_package_name }}/labextension/",
     "sharedPackages": {
       "@jupyter-widgets/base": {
         "bundled": false,

--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -55,6 +55,7 @@
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4.0.0-beta.1"
   },
   "devDependencies": {
+    "@jupyterlab/builder": "^3.0.0-beta.7",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/expect.js": "^0.3.29",

--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -51,10 +51,10 @@
     "watch:nbextension": "webpack --watch"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4.0.0-beta.1"
+    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^3.0.0-beta.8",
+    "@jupyterlab/builder": "^3.0.0",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/expect.js": "^0.3.29",

--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -55,7 +55,7 @@
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4.0.0-beta.1"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^3.0.0-beta.7",
+    "@jupyterlab/builder": "^3.0.0-beta.8",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/expect.js": "^0.3.29",

--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -30,13 +30,14 @@
   },
   "scripts": {
     "build": "npm run build:lib && npm run build:nbextension",
-    "build:labextension": "npm run clean:labextension && mkdirp {{ cookiecutter.python_package_name }}/labextension && cd {{ cookiecutter.python_package_name }}/labextension && npm pack ../..",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
     "build:nbextension": "webpack -p",
     "build:all": "npm run build:labextension && npm run build:nbextension",
     "clean": "npm run clean:lib && npm run clean:nbextension",
     "clean:lib": "rimraf lib",
-    "clean:labextension": "rimraf {{ cookiecutter.python_package_name }}/labextension",
+    "clean:labextension": "rimraf {{ cookiecutter.python_package_name }}/jupyterlab_widgets/lab3extension",
     "clean:nbextension": "rimraf {{ cookiecutter.python_package_name }}/nbextension/static/index.js",
     "lint": "eslint . --ext .ts,.tsx --fix",
     "lint:check": "eslint . --ext .ts,.tsx",
@@ -51,7 +52,7 @@
     "watch:nbextension": "webpack --watch"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3"
+    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4.0.0-beta.1"
   },
   "devDependencies": {
     "@phosphor/application": "^1.6.0",
@@ -90,6 +91,13 @@
     "webpack-cli": "^3.1.2"
   },
   "jupyterlab": {
-    "extension": "lib/plugin"
+    "extension": "lib/plugin",
+    "outputDir": "jupyterlab_widgets/static",
+    "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      }
+    }
   }
 }

--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -22,13 +22,14 @@ from setuptools import setup
 name = '{{ cookiecutter.python_package_name }}'
 
 # Ensure a valid python version
-ensure_python('>=3.4')
+ensure_python('>=3.6')
 
 # Get our version
 version = get_version(pjoin(name, '_version.py'))
 
 nb_path = pjoin(HERE, name, 'nbextension', 'static')
-lab_path = pjoin(HERE, name, 'labextension')
+# lab_path = pjoin(HERE, name, 'labextension')
+lab3_path = pjoin(HERE, name, 'lab3extension')
 
 # Representative files that should exist after a successful build
 jstargets = [
@@ -39,14 +40,18 @@ jstargets = [
 package_data_spec = {
     name: [
         'nbextension/static/*.*js*',
-        'labextension/*.tgz'
+        # 'labextension/*.tgz',
+        'lab3extension/*'
     ]
 }
+
+labext_name = "{{ cookiecutter.npm_package_name }}"
 
 data_files_spec = [
     ('share/jupyter/nbextensions/{{ cookiecutter.python_package_name}}',
         nb_path, '*.js*'),
-    ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
+    ("share/jupyter/labextensions/%s" % labext_name, lab3_path, "*.*"),
+#    ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
     ('etc/jupyter/nbconfig/notebook.d' , HERE, '{{ cookiecutter.python_package_name}}.json')
 ]
 
@@ -85,6 +90,7 @@ setup_args = dict(
         'Framework :: Jupyter',
     ],
     include_package_data = True,
+    python_requires=">=3.6",
     install_requires = [
         'ipywidgets>=7.0.0',
     ],

--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -29,7 +29,7 @@ version = get_version(pjoin(name, '_version.py'))
 
 nb_path = pjoin(HERE, name, 'nbextension', 'static')
 # lab_path = pjoin(HERE, name, 'labextension')
-lab3_path = pjoin(HERE, name, 'lab3extension')
+lab3_path = pjoin(HERE, name, 'labextension')
 
 # Representative files that should exist after a successful build
 jstargets = [
@@ -41,7 +41,7 @@ package_data_spec = {
     name: [
         'nbextension/static/*.*js*',
         # 'labextension/*.tgz',
-        'lab3extension/*'
+        'labextension/*'
     ]
 }
 
@@ -59,7 +59,7 @@ data_files_spec = [
 cmdclass = create_cmdclass('jsdeps', package_data_spec=package_data_spec,
     data_files_spec=data_files_spec)
 cmdclass['jsdeps'] = combine_commands(
-    install_npm(HERE, build_cmd='build:all'),
+    install_npm(HERE, build_cmd='build'),
     ensure_targets(jstargets),
 )
 


### PR DESCRIPTION
This is basically functional with jlab 3 beta 8. The paths may need to be tweaked so the install works (e.g., the files are copied to the right places), etc., but the generated files seem to basically be in good order.

Right now this cookiecutter does not generate a jlab 2 package. It may be possible to generate and include both a jlab 2 and jlab 3 package.

CC @vidartf 