### PR TITLE
Fix name of top-level JSON install file?

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -50,7 +50,7 @@ data_files_spec = [
     ('share/jupyter/nbextensions/{{ cookiecutter.python_package_name }}', '{{ cookiecutter.python_package_name }}/nbextension', '**'),
     ('share/jupyter/labextensions/{{ cookiecutter.npm_package_name }}', '{{ cookiecutter.python_package_name }}/labextension', '**'),
     ('share/jupyter/labextensions/{{ cookiecutter.npm_package_name }}', '.', 'install.json'),
-    ('etc/jupyter/nbconfig/notebook.d', '.', '{{ cookiecutter.npm_package_name }}.json'),
+    ('etc/jupyter/nbconfig/notebook.d', '.', '{{ cookiecutter.python_package_name }}.json'),
 ]
 
 


### PR DESCRIPTION
The `setup.py` points to `{{ cookiecutter.npm_package_name }}.json`, but the file name itself is `{{ cookiecutter.python_package_name }}.json`. This seems like an oversight.