### PR TITLE
Remove invalid quotes in setup.cfg

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.cfg
+++ b/{{cookiecutter.github_project_name}}/setup.cfg
@@ -3,5 +3,5 @@ universal=1
 
 [metadata]
 long_description = file: README.md
-long_description_content_type = "text/markdown"
+long_description_content_type = text/markdown
 license_file = LICENSE.txt


### PR DESCRIPTION
I had to remove these quotes to be able to publish to PyPI.

Without this change, I get this error:
```
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
'"text/markdown"' is an invalid value for Description-Content-Type. Error: Invalid description content type: type/subtype is not valid See https://packaging.python.org/specifications/core-metadata for more information.
```