### PR TITLE
add setup.py to MANIFEST for metadata

### DIFF
--- a/{{cookiecutter.github_project_name}}/MANIFEST.in
+++ b/{{cookiecutter.github_project_name}}/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE.txt
 include README.md
 
+include setup.py
 include pyproject.toml
 include pytest.ini
 include .coverage.rc


### PR DESCRIPTION
necessary in order for the wheel building process to correctly grab the metadata. At least until the metadata gets moved to setup.cfg.

Long term using the `jupyter_packaging` build backend and moving metadata into the setup.cfg is a better solution. But this should fix https://github.com/jupyter-widgets/widget-ts-cookiecutter/issues/112

based on https://github.com/pypa/twine/issues/853#issuecomment-1006534285