### PR TITLE
Update webpack dependency to avoid openssl errors

### DIFF
--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -78,7 +78,7 @@
     "ts-jest": "^26.0.0",
     "ts-loader": "^8.0.0",
     "typescript": "~4.1.3",
-    "webpack": "^5.0.0",
+    "webpack": "^5.61.0",
     "webpack-cli": "^4.0.0"
   },
   "jupyterlab": {


### PR DESCRIPTION
Fixes `ERR_OSSL_EVP_UNSUPPORTED` because openssl 3 no longer provides md4. https://github.com/webpack/webpack/releases/tag/v5.61.0


@martinRenou 