### PR TITLE
Quote watch argument

### DIFF
--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -43,7 +43,7 @@
     "lint:check": "eslint . --ext .ts,.tsx",
     "prepack": "yarn run build:lib",
     "test": "jest",
-    "watch": "npm-run-all -p watch:*",
+    "watch": "npm-run-all -p 'watch:*'",
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch --mode=development",
     "watch:labextension": "jupyter labextension watch ."


### PR DESCRIPTION
I tried following the README:

https://github.com/jupyter-widgets/widget-ts-cookiecutter/blob/94f9d384331150655c18a08d94307280c32adedd/README.md?plain=1#L94-L95

The `yarn run watch` failed for me, using node v16.17.1 and yarn 3.4.1:

> No matches found: "watch:*"

It works if I run `node_modules/.bin/npm-run-all -p 'watch:*'` in shell. It also works if I quote the argument. Looks to me like something is trying to expand that glob before invoking the binary. `strace` shows that the command doesn't get passed to `sh -c` as a whole. And `npm-run-all` isn't even executed so the error message is not coming from it. On the plus side, the fact that apparently these commands get executed by code inside node means portability should be no concern, and if single quotes work for me they hopefully work for everyone.