### PR TITLE
Fix: use `jlpm` to install dependencies

### DIFF
--- a/{{cookiecutter.github_project_name}}/pyproject.toml
+++ b/{{cookiecutter.github_project_name}}/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 path = "."
 build_cmd = "build:prod"
+npm = ["jlpm"]
 
 [tool.tbump]
 field = [


### PR DESCRIPTION
`hatch-jupyter-builder` let's us choose which package manager to use. 

This PR uses `jlpm` instead of `yarn` to install the NodeJS dependencies. I have no idea whether there is a reason to avoid using the bundled yarn from JupyterLab. If we want to require that users install and use `yarn`, then we'd need to change this to `yarn`. However, the benefit of `jlpm` is that it's available from PyPI, so any sdist installation will just work according to PEP 517. If we require `yarn` here, builds from an sdist will fail if the host does not have the binary.

Fixes #124 and fixes #127.