### PR TITLE
Fix labextension install path

### DIFF
--- a/{{cookiecutter.github_project_name}}/pyproject.toml
+++ b/{{cookiecutter.github_project_name}}/pyproject.toml
@@ -66,9 +66,9 @@ artifacts = [
 
 [tool.hatch.build.targets.wheel.shared-data]
 "{{ cookiecutter.python_package_name }}/nbextension" = "share/jupyter/nbextensions/{{ cookiecutter.python_package_name }}"
-"{{ cookiecutter.python_package_name }}/labextension" = "share/jupyter/labextensions/{{ cookiecutter.python_package_name }}"
+"{{ cookiecutter.python_package_name }}/labextension" = "share/jupyter/labextensions/{{ cookiecutter.npm_package_name }}"
 "./install.json" = "share/jupyter/labextensions/{{ cookiecutter.python_package_name }}/install.json"
-"./{{ cookiecutter.python_package_name }}.json" = "etc/jupyter/nbconfig/notebook.d/{{ cookiecutter.python_package_name }}.json"
+"./{{ cookiecutter.python_package_name }}.json" = "etc/jupyter/nbconfig/notebook.d/{{ cookiecutter.npm_package_name }}.json"
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
Fix #131.

Fix `shared-data` config to align with `dest` in `_jupyter_labextension_paths`.

Fixing `dest` instead doesn't work. Maybe it's an issue of ipywidgets or jupyterlab, because
https://jupyterlab.readthedocs.io/en/latest/extension/extension_dev.html#distributing-prebuilt-extensions says "typically", not "exactly"
> To distribute a prebuilt extension, copy its [output directory](https://jupyterlab.readthedocs.io/en/latest/extension/extension_dev.html#outputdir) to a location where JupyterLab will find it, typically `<sys-prefix>/share/jupyter/labextensions/<package-name>`