### PR TITLE
update package.json devDependenciesComments to reflect devDependencies

### DIFF
--- a/{{cookiecutter.github_project_name}}/package.json
+++ b/{{cookiecutter.github_project_name}}/package.json
@@ -83,9 +83,9 @@
     "webpack-cli": "^5.1.4"
   },
   "devDependenciesComments": {
-    "@jupyterlab/builder": "pinned to the latest JupyterLab 3.x release",
-    "@lumino/application": "pinned to the latest Lumino 1.x release",
-    "@lumino/widgets": "pinned to the latest Lumino 1.x release"
+    "@jupyterlab/builder": "pinned to the latest JupyterLab 4.x release",
+    "@lumino/application": "pinned to the latest Lumino 2.x release",
+    "@lumino/widgets": "pinned to the latest Lumino 2.x release"
   },
   "jupyterlab": {
     "extension": "lib/plugin",


### PR DESCRIPTION
`devDependencies` in `package.json` has:

```
"@jupyterlab/builder": "^4.0.11",
"@lumino/application": "^2.3.0",
"@lumino/widgets": "^2.3.1",
```

but `devDependenciesComments` has jupyterlab 3.x, lumino 1.x